### PR TITLE
refactor: gitlab webhook add branch project resolver

### DIFF
--- a/prisma/migrations/20250718035944_drop_unique_constraints_project_name_repository/migration.sql
+++ b/prisma/migrations/20250718035944_drop_unique_constraints_project_name_repository/migration.sql
@@ -1,0 +1,5 @@
+-- DropIndex
+DROP INDEX `Project_name_key` ON `Project`;
+
+-- DropIndex
+DROP INDEX `Project_repository_key` ON `Project`;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,8 +27,8 @@ enum EventType {
 
 model Project {
   id         Int      @id @default(autoincrement())
-  name       String   @unique
-  repository String   @unique
+  name       String
+  repository String
   events     Event[]
   tickets    Ticket[]
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,8 +15,8 @@ app.get("/", (_req: Request, res: Response) => {
 
 
 app.post("/webhook/gitlab", async (req: Request, res: Response) => {
-
-  const webhook = GitlabWeebhook(req.body);
+ 
+  const webhook = GitlabWeebhook(req);
 
   const isSuccess = await webhook.save();
 

--- a/src/lib/github-webhook.ts
+++ b/src/lib/github-webhook.ts
@@ -21,14 +21,19 @@ export const GithubWebhook = async (req: Request, res: Response) => {
 
     const repo = payload.repository;
     const username = payload.pusher?.name;
-    const project = await prisma.project.upsert({
+
+    let project = await prisma.project.findFirst({
       where: { repository: repo.full_name },
-      update: {},
-      create: {
-        name: repo.name,
-        repository: repo.full_name,
-      },
     });
+
+    if(!project) {
+      project = await prisma.project.create({
+        data: {
+          name: repo.name,
+          repository: repo.full_name,
+        },
+      });
+    }
 
     const user = await prisma.user.upsert({
       where: { username },
@@ -144,14 +149,18 @@ const handleOpenedEvent = async (payload: any, res: Response) => {
     }
 
     // 1. Find or create the project
-    const project = await prisma.project.upsert({
+    let project = await prisma.project.findFirst({
       where: { repository: repo.full_name },
-      update: {},
-      create: {
-        name: repo.name,
-        repository: repo.full_name,
-      },
     });
+
+    if(!project) {
+      project = await prisma.project.create({
+        data: {
+          name: repo.name,
+          repository: repo.full_name,
+        },
+      });
+    }
 
     // 2. Find or create the user
     const user = await prisma.user.upsert({

--- a/src/lib/helper.ts
+++ b/src/lib/helper.ts
@@ -25,7 +25,7 @@ export const resolveEntities = async (
   const ticketCodeMatch = branch.match(/([A-Z]+-\d+)/i);
   const ticketCode = ticketCodeMatch ? ticketCodeMatch[1].toUpperCase() : null;
 
-  const project = await prisma.project.findUnique({
+  const project = await prisma.project.findFirst({
     where: { repository: repo.full_name },
   });
   if (!project) throw new Error("Project not found");


### PR DESCRIPTION
**Changes**
Handle single repository multi project through branch names

**Usage**
Append the branch names idetified as project in to the webhook url `?branch-projects=branch-po1`

**Example**: `https://lanexinsight.com/webhook/gitlab?branch-projects=project-001,branch-projects=project-002`